### PR TITLE
Add batch retrieval of IANA timezones

### DIFF
--- a/Cencora.Azure.Timevault/src/Api/GetIanaTimezoneByLocationBatch.cs
+++ b/Cencora.Azure.Timevault/src/Api/GetIanaTimezoneByLocationBatch.cs
@@ -1,0 +1,62 @@
+// Copyright 2024 Cencora, All rights reserved.
+//
+// Written by Felix Kahle, A123234, felix.kahle@worldcourier.de
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Cencora.Azure.Timevault
+{
+    public class GetIanaTimezoneByLocationBatch
+    {
+        /// <summary>
+        /// The logger instance.
+        /// </summary>
+        private readonly ILogger<GetIanaTimezoneByLocationBatch> _logger;
+
+        /// <summary>
+        /// The timevault service instance.
+        /// </summary>
+        private readonly ITimevaultService _timevaultService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetIanaTimezoneByLocationBatch"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="timevaultService">The timevault service instance.</param>
+        public GetIanaTimezoneByLocationBatch(ILogger<GetIanaTimezoneByLocationBatch> logger, ITimevaultService timevaultService)
+        {
+            _logger = logger;
+            _timevaultService = timevaultService;
+        }
+
+        [Function("getIanaTimezoneByLocationBatch")]
+        public async Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequest req)
+        {
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            if (string.IsNullOrEmpty(requestBody))
+            {
+                return new BadRequestObjectResult("The request body cannot be empty.");
+            }
+
+            var locationBatch = JsonSerializer.Deserialize<List<Location>>(requestBody);
+            if (locationBatch == null || !locationBatch.Any())
+            {
+                return new BadRequestObjectResult("The request body must contain a non-empty array of location objects.");
+            }
+
+            Dictionary<Location, string?> result = await _timevaultService.GetIanaTimezoneBatchAsync(locationBatch);
+
+            result.Select(x => new GetIanaTimezoneByLocationResult
+            {
+                Location = x.Key,
+                IanaTimezone = x.Value
+            }).ToList();
+
+            return new OkObjectResult(result);
+        }
+    }
+}

--- a/Cencora.Azure.Timevault/src/Api/ITimevaultService.cs
+++ b/Cencora.Azure.Timevault/src/Api/ITimevaultService.cs
@@ -38,6 +38,13 @@ namespace Cencora.Azure.Timevault
         Task<string?> GetIanaTimezoneAsync(Location location);
 
         /// <summary>
+        /// Retrieves the IANA timezones for a batch of locations asynchronously.
+        /// </summary>
+        /// <param name="locations">The collection of locations for which to retrieve the IANA timezones.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a dictionary where the keys are the locations and the values are the corresponding IANA timezones.</returns>
+        Task<Dictionary<Location, string?>> GetIanaTimezoneBatchAsync(IEnumerable<Location> locations);
+
+        /// <summary>
         /// Determines if an update to the IANA timezone code is required for the specified Timevault document.
         /// </summary>
         /// <param name="document">The Timevault document to check.</param>

--- a/Cencora.Azure.Timevault/src/Api/TimevaultService.cs
+++ b/Cencora.Azure.Timevault/src/Api/TimevaultService.cs
@@ -173,23 +173,7 @@ namespace Cencora.Azure.Timevault
                 {
                     _logger.LogWarning($"1 Timevault document expected for location: {location}, but {documents.Count} found. Using the first document found.");
                 }
-
-                // Check if an update to the IANA timezone code is required.
-                if (RequiredIanaTimezoneCodeUpdate(foundDocument))
-                {
-                    _logger.LogInformation($"Timevault document found for location: {location}, but the IANA timezone code is outdated. Updating...");
-                    string? ianaCode = await MapsSearchTimezoneAsync(foundDocument.Coordinate);
-                    if (ianaCode == null)
-                    {
-                        _logger.LogWarning($"No IANA timezone code found for coordinate: {foundDocument.Coordinate}");
-                        return null;
-                    }
-
-                    foundDocument.IanaCode = ianaCode;
-                    foundDocument.LastIanaCodeUpdateTimestamp = DateTime.UtcNow;
-                    await UpsertTimevaultDocumentAsync(foundDocument);
-                }
-
+                await TryUpdateTimevaultDocumentIanaCode(foundDocument);
                 return foundDocument.IanaCode;
             }
             else
@@ -217,6 +201,69 @@ namespace Cencora.Azure.Timevault
         }
 
         /// <summary>
+        /// Retrieves the IANA timezone codes for a batch of locations asynchronously.
+        /// </summary>
+        /// <param name="locations">The collection of locations to retrieve the IANA timezone codes for.</param>
+        /// <returns>A dictionary containing the IANA timezone code for each location. If a location is not found or an error occurs, the value will be null.</returns>
+        public async Task<Dictionary<Location, string?>> GetIanaTimezoneBatchAsync(IEnumerable<Location> locations)
+        {
+            // Stores the result of the IANA timezone code search for each location.
+            Dictionary<Location, string?> result = new Dictionary<Location, string?>();
+
+            // Make sure that the locations are unique.
+            locations = locations.Distinct();
+
+            // All locations that have not been found in the Timevault database.
+            // These locations will be searched for and added to the database.
+            List<Location> locationsToSearch = new List<Location>();
+
+            foreach (Location location in locations)
+            {
+                IList<TimevaultDocument> documents = await SearchTimevaultAsync(location);
+                if (documents.Any())
+                {
+                    TimevaultDocument foundDocument = documents.First();
+                    if (documents.Count > 1)
+                    {
+                        _logger.LogWarning($"1 Timevault document expected for location: {location}, but {documents.Count} found. Using the first document found.");
+                    }
+                    await TryUpdateTimevaultDocumentIanaCode(foundDocument);
+                    result.Add(location, foundDocument.IanaCode);
+                }
+                else
+                {
+                    locationsToSearch.Add(location);
+                }
+            }
+
+            if (locationsToSearch.Any())
+            {
+                Dictionary<Location, GeoCoordinate?> locationGeoCoordinates = await MapsSearchlocationes(locationsToSearch);
+                foreach (var locationGeoCoordinatePair in locationGeoCoordinates)
+                {
+                    if (locationGeoCoordinatePair.Value == null)
+                    {
+                        result.Add(locationGeoCoordinatePair.Key, null);
+                        continue;
+                    }
+
+                    string? ianaCode = await MapsSearchTimezoneAsync(locationGeoCoordinatePair.Value.Value);
+                    if (string.IsNullOrEmpty(ianaCode))
+                    {
+                        result.Add(locationGeoCoordinatePair.Key, null);
+                        continue;
+                    }
+
+                    TimevaultDocument newDocument = new TimevaultDocument(ianaCode, locationGeoCoordinatePair.Key, locationGeoCoordinatePair.Value.Value, DateTime.UtcNow);
+                    await UpsertTimevaultDocumentAsync(newDocument);
+                    result.Add(locationGeoCoordinatePair.Key, ianaCode);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Determines if an update to the IANA timezone code is required for the specified Timevault document.
         /// </summary>
         /// <param name="document">The Timevault document to check.</param>
@@ -226,6 +273,44 @@ namespace Cencora.Azure.Timevault
             DateTime now = DateTime.UtcNow;
             DateTime lastUpdated = document.LastIanaCodeUpdateTimestamp;
             return (now - lastUpdated) > TimeSpan.FromMinutes(_settings.IanaCodeUpdateIntervalInMinutes);
+        }
+
+        /// <summary>
+        /// Updates the IANA code of a Timevault document based on its coordinate.
+        /// </summary>
+        /// <param name="document">The Timevault document to update.</param>
+        /// <returns>The updated Timevault document.</returns>
+        public async Task<TimevaultDocument> UpdateTimevaultDocumentIanaCode(TimevaultDocument document)
+        {
+            string? ianaCode = await MapsSearchTimezoneAsync(document.Coordinate);
+            if (ianaCode == null)
+            {
+                _logger.LogWarning($"No IANA timezone code found for coordinate: {document.Coordinate}");
+                return document;
+            }
+
+            document.IanaCode = ianaCode;
+            document.LastIanaCodeUpdateTimestamp = DateTime.UtcNow;
+            await UpsertTimevaultDocumentAsync(document);
+
+            return document;
+        }
+
+        /// <summary>
+        /// Tries to update the IANA timezone code of a Timevault document.
+        /// </summary>
+        /// <param name="document">The Timevault document to update.</param>
+        /// <returns>
+        /// The updated Timevault document if the IANA timezone code needs to be updated,
+        /// otherwise returns the original document.
+        /// </returns>
+        public async Task<TimevaultDocument> TryUpdateTimevaultDocumentIanaCode(TimevaultDocument document)
+        {
+            if (RequiredIanaTimezoneCodeUpdate(document))
+            {
+                return await UpdateTimevaultDocumentIanaCode(document);
+            }
+            return document;
         }
 
         /// <summary>


### PR DESCRIPTION
***This commit adds a new method, GetIanaTimezoneBatchAsync, to the ITimevaultService interface and TimevaultService class. This method allows for the retrieval of IANA timezones for a batch of locations asynchronously. The method takes a collection of locations as input and returns a dictionary where the keys are the locations and the values are the corresponding IANA timezones. The implementation includes searching for existing Timevault documents for each location and updating the IANA timezone code if necessary. If a location is not found in the Timevault database, it is searched for using the Maps API and added to the database.